### PR TITLE
Feat: Add random restarts to pgd

### DIFF
--- a/conf/attacks/attacks.yaml
+++ b/conf/attacks/attacks.yaml
@@ -248,6 +248,8 @@ pgd:
   optimizer_config:
     weight_decay: 0.0
     betas: [0.9, 0.999]
+  random_restart_interval: 40
+  random_restart_epsilon: 0.1
 pgd_discrete:
   name: pgd_discrete
   type: hybrid


### PR DESCRIPTION
This pull request introduces a new feature for random restarts in the PGD attack implementation. The changes add configuration options and logic to periodically reset perturbations during the attack process, reducing the chance of getting stuck in suboptimal local minima

### Feature: Random Restarts in PGD Attack

#### Configuration Updates:
* Added `random_restart_interval` and `random_restart_epsilon` parameters to the `pgd:` configuration in `conf/attacks/attacks.yaml`. These parameters control the frequency and magnitude of randomness of each restart. ([conf/attacks/attacks.yamlR251-R252](diffhunk://#diff-e756223884f9506bda2f0f2269c26663df298c522ab9b094cca5bcbf9f81d812R251-R252))
* Updated the `PGDConfig` class in `src/attacks/pgd.py` to include the new parameters with default values: `random_restart_interval` (default `0`) and `random_restart_epsilon` (default `0.1`). ([src/attacks/pgd.pyR56-R57](diffhunk://#diff-59d6899252e5e32d84c72fb0fcf1156c209b4f80bb8057283fa7e6695e2fdbceR56-R57))

#### Implementation Updates:
* Modified the `_perform_optimizer_step` method in `src/attacks/pgd.py` to incorporate random restarts. If `random_restart_interval` is greater than 0 and the current step is a multiple of the interval, the perturbations are reset using a random noise scaled by `random_restart_epsilon`. ([src/attacks/pgd.pyL486-R495](diffhunk://#diff-59d6899252e5e32d84c72fb0fcf1156c209b4f80bb8057283fa7e6695e2fdbceL486-R495))
* Updated the `attack_batch` method in `src/attacks/pgd.py` to pass the current step to `_perform_optimizer_step`, enabling step-based logic for random restarts. ([src/attacks/pgd.pyL250-R254](diffhunk://#diff-59d6899252e5e32d84c72fb0fcf1156c209b4f80bb8057283fa7e6695e2fdbceL250-R254))