### PR TITLE
Left padded generation size fixed

### DIFF
--- a/src/lm_utils/generation.py
+++ b/src/lm_utils/generation.py
@@ -323,7 +323,7 @@ def generate_ragged(
             lengths = [
                 {
                     "padding": embeddings.size(1) - e.size(0),
-                    "generation": max_new_tokens - e.size(0),
+                    "generation": max_new_tokens + e.size(0),
                 }
                 for e in embedding_list
             ]


### PR DESCRIPTION
Left padded generation had a small bug. It considers the "padding" part and the "generation" part per batch element. 
Padding part is padded embedding length - original embedding length and the generation part should be max_new_tokens + original embedding length and not "-", as it was before. Then, padding and generation sum to the same length for each batch element. 

Branch can be deleted at merge.