### PR TITLE
Reset PAIR defaults 

### DIFF
--- a/adversariallm/attacks/pair.py
+++ b/adversariallm/attacks/pair.py
@@ -71,10 +71,10 @@ class PairConfig:
     type: str = "discrete"
     version: str = ""
     generation_config: GenerationConfig = field(default_factory=GenerationConfig)
-    num_streams: int = 1
+    num_streams: int = 30
     keep_last_num: int = 3
     seed: int = 0
-    num_steps: int = 20
+    num_steps: int = 3
     attack_model: AttackModelConfig = field(default_factory=AttackModelConfig)
     target_model: TargetModelConfig = field(default_factory=TargetModelConfig)
     judge_model: JudgeModelConfig = field(default_factory=JudgeModelConfig)
@@ -83,10 +83,6 @@ class PairConfig:
 class PAIRAttack(Attack):
     def __init__(self, config):
         super().__init__(config)
-        if self.config.num_steps < 30:
-            logging.warning(f"The PAIR paper used num_steps=30, but you have set it to {self.config.num_steps}.")
-        if self.config.num_streams < 3:
-            logging.warning(f"The PAIR paper used num_streams=3, but you have set it to {self.config.num_streams}.")
 
     def run(
         self,

--- a/conf/attacks/attacks.yaml
+++ b/conf/attacks/attacks.yaml
@@ -279,9 +279,9 @@ pair:
   version: 0.0.2
   seed: ${attacks._default.seed}
   generation_config: ${attacks._default.generation_config}
-  num_streams: 1
+  num_streams: 30
   keep_last_num: 3
-  num_steps: 20
+  num_steps: 3
   attack_model:
     id: lmsys/vicuna-13b-v1.5
     tokenizer_id: lmsys/vicuna-13b-v1.5


### PR DESCRIPTION
Addressing #48, the PAIR default params are set to:
```yaml
num_streams: 30
num_steps: 3
```

I checked performance compared to the previous defaults:
- 1x20 H100 median 360.2s 
- 30x3 H100 median 344.8s

So the defaults of the paper seem reasonable with respect to compute.