### PR TITLE
Fix PAIR FLOPs accounting and multi-stream completion merging

### DIFF
--- a/adversariallm/attacks/pair.py
+++ b/adversariallm/attacks/pair.py
@@ -396,8 +396,8 @@ class TargetLM:
             top_p=self.top_p,
             return_tokens=True,
         )
+        flops = get_flops(self.model, sum(len(t) for t in token_list), sum(len(o[0]) if len(o) > 0 else 0 for o in outputs_list), type="forward")
         outputs_list = [self.tokenizer.decode(o[0]) for o in outputs_list]  # only care about a single completion
-        flops = get_flops(self.model, sum(len(t) for t in token_list), sum(len(o[0]) for o in outputs_list), type="forward")
 
         return outputs_list, token_list, flops
 
@@ -456,8 +456,8 @@ class JudgeLM:
             max_new_tokens=self.max_new_tokens,
             return_tokens=True,
         )
+        flops = get_flops(self.model, sum(len(t) for t in token_list), sum(len(o[0]) if len(o) > 0 else 0 for o in outputs_list), type="forward")
         outputs_list = [self.tokenizer.decode(o[0]) for o in outputs_list]
-        flops = get_flops(self.model, sum(len(t) for t in token_list), sum(len(o[0]) for o in outputs_list), type="forward")
         # Extract scores
         scores = [self.process_output(output) for output in outputs_list]
         return scores, flops

--- a/adversariallm/attacks/pair.py
+++ b/adversariallm/attacks/pair.py
@@ -180,9 +180,18 @@ class PAIRAttack(Attack):
                 # we already have the first completion, so we only need to generate the rest
                 num_return_sequences=self.config.generation_config.num_return_sequences-1,
             )
+            extras_by_step = [[] for _ in range(len(completions))]
             for flat_idx, new_completions in enumerate(additional_completions):
                 step_idx = flat_idx // self.config.num_streams
-                completions[step_idx].extend(new_completions)
+                extras_by_step[step_idx].append(new_completions)
+            for step_idx, per_stream_extras in enumerate(extras_by_step):
+                base_completions = completions[step_idx]
+                reordered = []
+                for stream_idx, base_completion in enumerate(base_completions):
+                    reordered.append(base_completion)
+                    if stream_idx < len(per_stream_extras):
+                        reordered.extend(per_stream_extras[stream_idx])
+                completions[step_idx] = reordered
         steps = []
         for i in range(self.config.num_steps):
             step = AttackStepResult(

--- a/adversariallm/attacks/pair.py
+++ b/adversariallm/attacks/pair.py
@@ -180,8 +180,9 @@ class PAIRAttack(Attack):
                 # we already have the first completion, so we only need to generate the rest
                 num_return_sequences=self.config.generation_config.num_return_sequences-1,
             )
-            for j, new_completions in enumerate(additional_completions):
-                completions[j].extend(new_completions)
+            for flat_idx, new_completions in enumerate(additional_completions):
+                step_idx = flat_idx // self.config.num_streams
+                completions[step_idx].extend(new_completions)
         steps = []
         for i in range(self.config.num_steps):
             step = AttackStepResult(

--- a/tests/test_attacks/test_pair.py
+++ b/tests/test_attacks/test_pair.py
@@ -141,3 +141,9 @@ def test_pair_num_return_sequences_with_many_streams(monkeypatch):
     assert len(result.runs) == 1
     assert len(result.runs[0].steps) == 1
     assert len(result.runs[0].steps[0].model_completions) == cfg.num_streams * cfg.generation_config.num_return_sequences
+    assert result.runs[0].steps[0].model_completions == [
+        "base-0", "extra-0-0", "extra-0-1",
+        "base-1", "extra-1-0", "extra-1-1",
+        "base-2", "extra-2-0", "extra-2-1",
+        "base-3", "extra-3-0", "extra-3-1",
+    ]

--- a/tests/test_attacks/test_pair.py
+++ b/tests/test_attacks/test_pair.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+
+import torch
 from omegaconf import OmegaConf
 
 from adversariallm.attacks.pair import PAIRAttack
@@ -70,3 +73,71 @@ def test_pair_attack():
         import traceback
         traceback.print_exc()
         raise
+
+
+def test_pair_num_return_sequences_with_many_streams(monkeypatch):
+    class DummyDataset:
+        def __iter__(self):
+            yield [
+                {"role": "user", "content": "prompt"},
+                {"role": "assistant", "content": "target"},
+            ]
+
+    class DummyModel:
+        name_or_path = "dummy-model"
+
+    class DummyTokenizer:
+        pass
+
+    cfg = SimpleNamespace(
+        seed=0,
+        num_steps=1,
+        num_streams=4,
+        generation_config=SimpleNamespace(
+            max_new_tokens=16,
+            temperature=0.0,
+            top_p=1.0,
+            top_k=0,
+            num_return_sequences=3,
+        ),
+        attack_model=SimpleNamespace(
+            id="dummy-model",
+            max_attempts=1,
+            max_new_tokens=16,
+            temperature=1.0,
+            top_p=0.9,
+        ),
+        target_model=SimpleNamespace(
+            max_new_tokens=16,
+            temperature=0.0,
+            top_p=1.0,
+        ),
+        judge_model=SimpleNamespace(id=None),
+    )
+
+    def _mock_get_attack(self, convs_list, prompts_list):
+        return [{"improvement": "x", "prompt": f"attack-{i}"} for i in range(len(convs_list))], 0
+
+    def _mock_get_response(self, conversations):
+        n = len(conversations)
+        return [f"base-{i}" for i in range(n)], [torch.tensor([i], dtype=torch.long) for i in range(n)], 0
+
+    def _mock_score(self, prompt_list, response_list):
+        return [1 for _ in prompt_list], 0
+
+    def _mock_generate_ragged_batched(model, tokenizer, token_list, **kwargs):
+        n = len(token_list)
+        extras_per_prompt = kwargs["num_return_sequences"]
+        return [[f"extra-{i}-{j}" for j in range(extras_per_prompt)] for i in range(n)]
+
+    monkeypatch.setattr("adversariallm.attacks.pair.AttackLM.get_attack", _mock_get_attack)
+    monkeypatch.setattr("adversariallm.attacks.pair.TargetLM.get_response", _mock_get_response)
+    monkeypatch.setattr("adversariallm.attacks.pair.JudgeLM.score", _mock_score)
+    monkeypatch.setattr("adversariallm.attacks.pair.generate_ragged_batched", _mock_generate_ragged_batched)
+
+    attack = PAIRAttack(cfg)
+    result = attack.run(DummyModel(), DummyTokenizer(), DummyDataset())
+
+    assert len(result.runs) == 1
+    assert len(result.runs[0].steps) == 1
+    assert len(result.runs[0].steps[0].model_completions) == cfg.num_streams * cfg.generation_config.num_return_sequences


### PR DESCRIPTION
This PR fixes two correctness issues in the PAIR attack implementation:

  1. FLOPs accounting in `TargetLM` and `JudgeLM` was computed after decoding token outputs to strings.
  2. Additional sampled completions (`num_return_sequences > 1`) were merged back into PAIR steps using the wrong index space for multi-stream runs.

  These changes do not change the PAIR algorithm itself. They fix bookkeeping and result assembly.
  
  
  
  ## Why this is needed

  ### 1. FLOPs accounting bug

  `TargetLM.get_response()` and `JudgeLM.score()` previously decoded token outputs into strings before computing FLOPs.

  That meant code of the form `len(o[0])` was operating on the first character of a decoded string rather than the first generated token sequence, which undercounted FLOPs and could also fail on empty outputs.

  This PR moves FLOPs computation to the token-output stage.

  ### 2. Multi-stream completion merge bug

  When `generation_config.num_return_sequences > 1`, PAIR first stores one base completion per stream and then requests the remaining sampled completions.

  Those extra completions come back flattened by prompt, but the old merge logic indexed directly into the per-step `completions` list. In multi-stream settings, that mixes flat prompt indices with PAIR step indices and can misassign completions or crash.

  This PR restores the correct step mapping by grouping each block of `num_streams` flattened prompts back into its originating PAIR step.
  
  

##  Tests succeeded. 