### PR TITLE
PAIR completion ordering by stream

### DIFF
--- a/adversariallm/attacks/pair.py
+++ b/adversariallm/attacks/pair.py
@@ -180,9 +180,18 @@ class PAIRAttack(Attack):
                 # we already have the first completion, so we only need to generate the rest
                 num_return_sequences=self.config.generation_config.num_return_sequences-1,
             )
+            extras_by_step = [[] for _ in range(len(completions))]
             for flat_idx, new_completions in enumerate(additional_completions):
                 step_idx = flat_idx // self.config.num_streams
-                completions[step_idx].extend(new_completions)
+                extras_by_step[step_idx].append(new_completions)
+            for step_idx, per_stream_extras in enumerate(extras_by_step):
+                base_completions = completions[step_idx]
+                reordered = []
+                for stream_idx, base_completion in enumerate(base_completions):
+                    reordered.append(base_completion)
+                    if stream_idx < len(per_stream_extras):
+                        reordered.extend(per_stream_extras[stream_idx])
+                completions[step_idx] = reordered
         steps = []
         for i in range(self.config.num_steps):
             step = AttackStepResult(

--- a/tests/test_attacks/test_pair.py
+++ b/tests/test_attacks/test_pair.py
@@ -141,3 +141,9 @@ def test_pair_num_return_sequences_with_many_streams(monkeypatch):
     assert len(result.runs) == 1
     assert len(result.runs[0].steps) == 1
     assert len(result.runs[0].steps[0].model_completions) == cfg.num_streams * cfg.generation_config.num_return_sequences
+    assert result.runs[0].steps[0].model_completions == [
+        "base-0", "extra-0-0", "extra-0-1",
+        "base-1", "extra-1-0", "extra-1-1",
+        "base-2", "extra-2-0", "extra-2-1",
+        "base-3", "extra-3-0", "extra-3-1",
+    ]


### PR DESCRIPTION
This PR makes PAIR's flattened `model_completions` ordering more consistent when `generation_config.num_return_sequences > 1`.

  The result schema stays the same:
  - one `AttackStepResult` per PAIR step
  - one flat `list[str]` in `model_completions`

  What changes is the ordering inside that flat list.

  ## New ordering

  For each PAIR step, completions are now grouped by stream:

  ```text
  [
    stream0_base,
    stream0_extra_1,
    stream0_extra_2,
    ...,
    stream1_base,
    stream1_extra_1,
    stream1_extra_2,
    ...,
  ]

  So with:

  - num_streams = 3
  - num_return_sequences = 4

  the flat list is ordered as:

  [
    s0_r0, s0_r1, s0_r2, s0_r3,
    s1_r0, s1_r1, s1_r2, s1_r3,
    s2_r0, s2_r1, s2_r2, s2_r3,
  ]

  where r0 is the original/base completion.

  ## Why this is useful

  Previously, PAIR stored completions in a mixed layout:

  [
    base_s0, base_s1, base_s2,
    extra_s0_1, extra_s0_2, ...,
    extra_s1_1, extra_s1_2, ...,
  ]

  That preserved step grouping, but it separated each stream's base completion from its additional sampled completions.

  The new ordering is easier to interpret and work with while preserving the existing flat result schema.